### PR TITLE
Update FAQ re: DevEdition and unsigned add-ons

### DIFF
--- a/_posts/2017-04-17-Dawn-Project-FAQ.md
+++ b/_posts/2017-04-17-Dawn-Project-FAQ.md
@@ -58,11 +58,11 @@ Fennec Aurora on Google Play is a recent addition and we believe merging this au
 Developer Edition, currently based off Aurora, will be updated to get builds from the Beta branch. There is nothing Developer Edition users need to do, they will update automatically to the Beta build keeping the Developer Edition themes, tools, and preferences as well as  the existing profile.
 
 ## Will I still be able to test add-ons with Developer Edition?
-You can continue to test unsigned add-ons on Nightly builds or [load WebExtensions temporarily](https://blog.mozilla.org/addons/2015/12/23/loading-temporary-add-ons/) in Beta and Release builds.
+Yes. You can also test unsigned add-ons on Nightly builds or [load WebExtensions temporarily](https://blog.mozilla.org/addons/2015/12/23/loading-temporary-add-ons/) in Beta and Release builds.
 
-We are also continuing to provide [unbranded builds](https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds) of the beta and release branches which are able to run unsigned add-ons - including bootstrapped - for development and experimentation. These versions will not be verified by QE, but will receive updates , which is an improvement to the [unbranded builds we currently provide](https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds) for add-on development..
+We are also continuing to provide [unbranded builds](https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds) of the beta and release branches which are able to run unsigned add-ons - including bootstrapped - for development and experimentation. These versions will not be verified by QE, but will receive updates , which is an improvement to the [unbranded builds we currently provide](https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds) for add-on development.
 
-The majority of Developer Edition users won't experience any disruption. However those developers who rely on unsigned add-ons will need to use Nightly builds until we have finalized the unsigned add-on builds specifically for those developers.
+The majority of Developer Edition users won't experience any disruption.
 
 ## How will you mitigate the quality risk from cutting 6-8 weeks of stabilization from the cycle?
 Instead of pushing to 100 % of the beta population at once, we will use a staged rollout mechanism to push to a subset of the beta population.


### PR DESCRIPTION
According to an email from @clarkbw:

> DE continues to allow unsigned add-ons.
> It is based off Beta, however it does have some different build flags.

The FAQ should be updated to reflect this.