### PR TITLE
use global variable for site domain name URL in metadata.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@ title: Release Management Blog
 description: Thoughts and facts on shipping quality software by the team that ships Firefox every 6 to 8 weeks
 extradescription: We talk here about release management at Mozilla, tooling helping decision-making, static analysis and community building around our pre-release channels.
 email: release-mgmt@mozilla.com
-url: "http://release.mozilla.org"
-github: "http://github.com/mozilla/release-blog"
+url: "https://release.mozilla.org"
+github: "https://github.com/mozilla/release-blog"
 highlighter: rouge
 
 # Navigation
@@ -11,7 +11,7 @@ navigation:
 - title: Twitter
   url: https://twitter.com/MozillaReleases
 - title: Team Wiki
-  url: http://wiki.mozilla.org/Release_Management
+  url: https://wiki.mozilla.org/Release_Management
 - title: Release Calendar
   url: https://wiki.mozilla.org/RapidRelease/Calendar
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,25 +6,25 @@
     <title>{{ page.title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="description" content="{{ site.description }}. {{ site.extradescription }}">
-    <meta name="image" content="https://release.mozilla.org/images/logos/750px-All-firefox-logos.png">
+    <meta name="image" content="{{ site.url }}/images/logos/750px-All-firefox-logos.png">
 
     <!-- Schema.org for Google -->
     <meta itemprop="name" content="{{ page.title }}">
     <meta itemprop="description" content="{{ site.description }}. {{ site.extradescription }}">
-    <meta itemprop="image" content="https://release.mozilla.org/images/logos/750px-All-firefox-logos.png">
+    <meta itemprop="image" content="{{ site.url }}/images/logos/750px-All-firefox-logos.png">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="{{ page.title }}">
     <meta name="twitter:description" content="{{ site.description }}. {{ site.extradescription }}">
     <meta name="twitter:site" content="@MozillaReleases">
-    <meta name="twitter:image:" content="https://release.mozilla.org/images/logos/750px-All-firefox-logos.png">
+    <meta name="twitter:image:" content="{{ site.url }}/images/logos/750px-All-firefox-logos.png">
 
     <!-- Open Graph general (Facebook, Pinterest & Google+) -->
     <meta property="og:title" content="{{ page.title }}">
     <meta property="og:description" content="{{ site.description }}. {{ site.extradescription }}">
-    <meta property="og:image" content="https://release.mozilla.org/images/logos/750px-All-firefox-logos.png">
-    <meta property="og:url" content="https://release.mozilla.org">
+    <meta property="og:image" content="{{ site.url }}/images/logos/750px-All-firefox-logos.png">
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}">
     <meta property="og:site_name" content="Mozilla Release Management blog">
     <meta property="og:locale" content="en-US">
     <meta property="og:type" content="website">
@@ -68,7 +68,7 @@
                 {% else %}
                 <li>
                 {% endif %}
-                    <a href="{{link.url}}">{{link.title}}</a>
+                    <a href="{{ link.url }}">{{link.title}}</a>
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
 issue #40: follow-up fixes after using Facebook validator
 
- https urls in config file
- use site variables in url metadata